### PR TITLE
Minor fix to python API and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__
-*/build/*
+**/build/*
 .vscode

--- a/mad_icp/apps/utils/utils.py
+++ b/mad_icp/apps/utils/utils.py
@@ -31,7 +31,4 @@ import numpy as np
 def write_transformed_pose(estimate_file, lidar_to_world, lidar_to_base):
 	base_to_lidar = np.linalg.inv(lidar_to_base)
 	base_to_world = np.dot(lidar_to_base, np.dot(lidar_to_world, base_to_lidar))
-	for row in range(3):
-		for col in range(4):
-			estimate_file.write(str(base_to_world[row, col]) + " ")
-	estimate_file.write("\n")
+	estimate_file.write(str(base_to_world[:3].reshape(12,))[1:-1] + "\n")


### PR DESCRIPTION
Thanks for you amazing contribution @simone-ferrari and team. Firstly, the package builds without issues, which is amazing. I am currently running your pipeline to see how it performs, and I ran into some small issues which I propose to fix in this PR.

1. The line `*/build/*` in `.gitignore` does not actually ignore the build directory.
2. The poses saved in KITTI format had a trailing whitespace at end of each line which was throwing an error (see image below) when passed to the commonly used [evo pipeline](https://github.com/MichaelGrupp/evo) for computing odometry evaluation metrics.

![image](https://github.com/user-attachments/assets/5b2d4812-bd52-41cb-a379-34dd8c6a394a)

I propose a fix two the above issues through the two small commits in this PR.