### PR TITLE
Fix build errors (cxx flags erased and std::precision header)

### DIFF
--- a/mad_icp/CMakeLists.txt
+++ b/mad_icp/CMakeLists.txt
@@ -5,7 +5,7 @@ project(mad_icp LANGUAGES CXX)
 
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS -Werror)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 
 # this is required only to compile apps in C++, if you work in Python this can be set to off
 # if need to compile C++ apps, when executing CMake run `cmake -DCOMPILE_CPP_APPS=ON ..`

--- a/mad_icp/apps/cpp_runners/bin_runner.cpp
+++ b/mad_icp/apps/cpp_runners/bin_runner.cpp
@@ -26,6 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <iomanip>
 #include <iostream>
 
 #include <Eigen/Core>


### PR DESCRIPTION
I had some build error while trying to compile the code for a embedded platform:
-CMAKE_CXX_FLAGS was erased while it can contain information before being written
-the header for std::precision was not included in a file using it
I think it can be useful for the source code!