### PR TITLE
ROS1 odometry and cloud publisher

### DIFF
--- a/mad_icp/apps/mad_icp.py
+++ b/mad_icp/apps/mad_icp.py
@@ -84,7 +84,9 @@ def main(data_path: Annotated[
         realtime: Annotated[
         bool, typer.Option(help="if true anytime realtime", show_default=True)] = False,
         noviz: Annotated[
-        bool, typer.Option(help="if true visualizer on", show_default=True)] = False) -> None:
+        bool, typer.Option(help="if true visualizer on", show_default=True)] = False,
+        noros: Annotated[
+        bool, typer.Option(help="if true do not publish to ros", show_default=True)] = False) -> None:
     if not data_path.exists():
         console.print(f"[red] {data_path} does not exist!")
         sys.exit(-1)
@@ -99,9 +101,10 @@ def main(data_path: Annotated[
         visualizer = Visualizer()
 
     try:
-        publisher = Ros1Publisher()
-    except Exception:
-        pass
+        if not noros:
+            publisher = Ros1Publisher()
+    except Exception as e:
+        console.print(f"[red] Error: {e}")
 
     reader_type = InputDataInterface.kitti
 
@@ -221,8 +224,6 @@ def main(data_path: Annotated[
                     visualizer.update(
                         pipeline.currentLeaves(), pipeline.modelLeaves(), lidar_to_world, pipeline.keyframePose()
                     )
-                    # TODO: publish PointCloud2 (consider using lidar_to_world or lidar_to_base and base_to_world)
-                    pass
                 else:
                     visualizer.update(pipeline.currentLeaves(),
                                       None, lidar_to_world, None)

--- a/mad_icp/apps/mad_icp.py
+++ b/mad_icp/apps/mad_icp.py
@@ -42,7 +42,7 @@ from mad_icp.apps.utils.ros_reader import Ros1Reader
 from mad_icp.apps.utils.ros2_reader import Ros2Reader
 from mad_icp.apps.utils.mcap_reader import McapReader
 from mad_icp.apps.utils.kitti_reader import KittiReader
-from mad_icp.apps.utils.ros_publisher import ImuAndCloudPublisher
+from mad_icp.apps.utils.ros_publisher import Ros1Publisher
 from mad_icp.apps.utils.visualizer import Visualizer
 from mad_icp.configurations.datasets.dataset_configurations import DatasetConfiguration_lut
 from mad_icp.configurations.mad_params import MADConfiguration_lut
@@ -97,10 +97,11 @@ def main(data_path: Annotated[
     publisher = None
     if not noviz:
         visualizer = Visualizer()
-        try:
-            publisher = ImuAndCloudPublisher()
-        except Exception:
-            pass
+
+    try:
+        publisher = Ros1Publisher()
+    except Exception:
+        pass
 
     reader_type = InputDataInterface.kitti
     
@@ -158,7 +159,6 @@ def main(data_path: Annotated[
     rho_ker = mad_icp_cf["rho_ker"]
     n = mad_icp_cf["n"]
 
-
     # check some params for machine
     if (realtime and num_keyframes > num_cores):
         console.print(
@@ -197,6 +197,7 @@ def main(data_path: Annotated[
             write_transformed_pose(estimate_file, base_to_world)
 
             if publisher is not None:
+                # import pdb; pdb.set_trace()
                 publisher.publish_imu(ts, base_to_world)
 
             if not noviz:

--- a/mad_icp/apps/mad_icp.py
+++ b/mad_icp/apps/mad_icp.py
@@ -191,7 +191,7 @@ def main(data_path: Annotated[
             t_delta = t_end - t_start
             t_delta_odom_ms = t_delta.total_seconds() * 1000
             print(
-                f"# {pipeline.currentID()}."
+                f"ID {pipeline.currentID()}: "
                 f"Time of reading points / odometry estimation [ms]: {t_delta_read_ms}, {t_delta_odom_ms}"
             )
 

--- a/mad_icp/apps/mad_icp.py
+++ b/mad_icp/apps/mad_icp.py
@@ -97,7 +97,10 @@ def main(data_path: Annotated[
     publisher = None
     if not noviz:
         visualizer = Visualizer()
-        publisher = ImuAndCloudPublisher()
+        try:
+            publisher = ImuAndCloudPublisher()
+        except Exception:
+            pass
 
     reader_type = InputDataInterface.kitti
     
@@ -193,15 +196,15 @@ def main(data_path: Annotated[
             base_to_world = get_transformed_pose(lidar_to_world, lidar_to_base)
             write_transformed_pose(estimate_file, base_to_world)
 
-            import pdb; pdb.set_trace()
-            publisher.publish_imu(ts, base_to_world)
+            if publisher is not None:
+                publisher.publish_imu(ts, base_to_world)
 
             if not noviz:
                 t_start = datetime.now()
                 if pipeline.isMapUpdated():
                     visualizer.update(pipeline.currentLeaves(), pipeline.modelLeaves(
                     ), lidar_to_world, pipeline.keyframePose())
-                    import pdb; pdb.set_trace()
+                    # import pdb; pdb.set_trace()
                     # TODO: publish PointCloud2
                     pass
                 else:

--- a/mad_icp/apps/utils/ros_publisher.py
+++ b/mad_icp/apps/utils/ros_publisher.py
@@ -1,51 +1,55 @@
 import rospy
 import numpy as np
+from tf import transformations
 from geometry_msgs.msg import Quaternion
-from sensor_msgs.msg import Imu, PointCloud2
+from sensor_msgs.msg import PointCloud2
 from std_msgs.msg import Header
+
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import Point, Pose, Quaternion
 
 from typing import Any
 
 
-class ImuAndCloudPublisher:
+class Ros1Publisher:
     def __init__(self):
         rospy.init_node('mad_icp', anonymous=True)
 
-        self.out_topic_imu = rospy.get_param('~out_topic_imu', '/odometry/imu')
+        self.out_topic_odom = rospy.get_param('~out_topic_odom', '/odometry/imu')
         self.out_topic_cloud = rospy.get_param('~out_topic_cloud', '/cloud_output')
         self.new_frame_id = rospy.get_param('~new_frame_id', 'imu_link')
 
         # Setup subscriber and publisher
-        self.imu_pub = rospy.Publisher(self.out_topic_imu, Imu, queue_size=10)
+        self.odom_pub = rospy.Publisher(self.out_topic_odom, Odometry, queue_size=10)
         self.cloud_pub = rospy.Publisher(self.out_topic_cloud, PointCloud2, queue_size=10)
 
         rospy.loginfo("MAD-ICP ROS publisher started:")
-        rospy.loginfo("  Output topic: %s", self.out_topic_imu)
+        rospy.loginfo("  Output topic: %s", self.out_topic_odom)
         rospy.loginfo("  Output frame_id: %s", self.new_frame_id)
 
     def publish_imu(self, ts: np.float64, base_to_world: np.ndarray):
 
-        # TODO: assert transform.shape == (4, 4), f"ncorrect transform shape: {transform.shape}""
+        assert base_to_world.shape == (4, 4), f"ncorrect base_to_world shape: {base_to_world.shape}"
 
-        # TODO: remove the below `msg_tmp` definition and fill in the `msg`` with `transform`
-        msg_tmp = Imu()
+        msg = Odometry()
+        header = Header()
+        header.stamp = rospy.Time(secs=int(ts // 1e9), nsecs=int(ts) % 1e9)
+        msg.header = header
+        msg.header.frame_id = self.new_frame_id
+
+        quat = transformations.quaternion_from_matrix(base_to_world)
         quat_out = [1, 0, 0, 0]
 
-        msg = Imu()
-        header = Header()
-        header.stamp.sec = int(ts // 1e-9)
-        header.stamp.nsec = int(ts) % 1e-9
-        msg.header = header
+        position = base_to_world[3, :3]
 
         msg.orientation = Quaternion(*list(quat_out))
         # `msg.orientation_covariance` <- leaving as default (all zeros)
-        msg.angular_velocity = msg_tmp.angular_velocity
+        # `msg.angular_velocity` <- leaving as default (all zeros)
         # `msg.angular_velocity_covariance` <- leaving as default (all zeros)
-        msg.linear_acceleration = msg_tmp.linear_acceleration
+        # `msg.linear_acceleration` <- leaving as default (all zeros)
         # `msg.linear_acceleration_covariance` <- leaving as default (all zeros)
 
-        # Update the frame_id
-        msg.header.frame_id = self.new_frame_id
+
 
         # Republish the message
-        self.imu_pub.publish(msg)
+        self.odom_pub.publish(msg)

--- a/mad_icp/apps/utils/ros_publisher.py
+++ b/mad_icp/apps/utils/ros_publisher.py
@@ -23,7 +23,7 @@ class ImuAndCloudPublisher:
         rospy.loginfo("  Output topic: %s", self.out_topic_imu)
         rospy.loginfo("  Output frame_id: %s", self.new_frame_id)
 
-    def publish_imu(self, ts: Any, base_to_world: np.ndarray):
+    def publish_imu(self, ts: np.float64, base_to_world: np.ndarray):
 
         # TODO: assert transform.shape == (4, 4), f"ncorrect transform shape: {transform.shape}""
 
@@ -33,7 +33,8 @@ class ImuAndCloudPublisher:
 
         msg = Imu()
         header = Header()
-        header.stamp = ts
+        header.stamp.sec = int(ts // 1e-9)
+        header.stamp.nsec = int(ts) % 1e-9
         msg.header = header
 
         msg.orientation = Quaternion(*list(quat_out))
@@ -48,5 +49,3 @@ class ImuAndCloudPublisher:
 
         # Republish the message
         self.imu_pub.publish(msg)
-
-        rospy.spin_once()

--- a/mad_icp/apps/utils/ros_publisher.py
+++ b/mad_icp/apps/utils/ros_publisher.py
@@ -1,0 +1,52 @@
+import rospy
+import numpy as np
+from geometry_msgs.msg import Quaternion
+from sensor_msgs.msg import Imu, PointCloud2
+from std_msgs.msg import Header
+
+from typing import Any
+
+
+class ImuAndCloudPublisher:
+    def __init__(self):
+        rospy.init_node('mad_icp', anonymous=True)
+
+        self.out_topic_imu = rospy.get_param('~out_topic_imu', '/odometry/imu')
+        self.out_topic_cloud = rospy.get_param('~out_topic_cloud', '/cloud_output')
+        self.new_frame_id = rospy.get_param('~new_frame_id', 'imu_link')
+
+        # Setup subscriber and publisher
+        self.imu_pub = rospy.Publisher(self.out_topic_imu, Imu, queue_size=10)
+        self.cloud_pub = rospy.Publisher(self.out_topic_cloud, PointCloud2, queue_size=10)
+
+        rospy.loginfo("MAD-ICP ROS publisher started:")
+        rospy.loginfo("  Output topic: %s", self.out_topic_imu)
+        rospy.loginfo("  Output frame_id: %s", self.new_frame_id)
+
+    def publish_imu(self, ts: Any, base_to_world: np.ndarray):
+
+        # TODO: assert transform.shape == (4, 4), f"ncorrect transform shape: {transform.shape}""
+
+        # TODO: remove the below `msg_tmp` definition and fill in the `msg`` with `transform`
+        msg_tmp = Imu()
+        quat_out = [1, 0, 0, 0]
+
+        msg = Imu()
+        header = Header()
+        header.stamp = ts
+        msg.header = header
+
+        msg.orientation = Quaternion(*list(quat_out))
+        # `msg.orientation_covariance` <- leaving as default (all zeros)
+        msg.angular_velocity = msg_tmp.angular_velocity
+        # `msg.angular_velocity_covariance` <- leaving as default (all zeros)
+        msg.linear_acceleration = msg_tmp.linear_acceleration
+        # `msg.linear_acceleration_covariance` <- leaving as default (all zeros)
+
+        # Update the frame_id
+        msg.header.frame_id = self.new_frame_id
+
+        # Republish the message
+        self.imu_pub.publish(msg)
+
+        rospy.spin_once()

--- a/mad_icp/apps/utils/utils_ext.py
+++ b/mad_icp/apps/utils/utils_ext.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+def get_transformed_pose(lidar_to_world, lidar_to_base) -> np.ndarray:
+	base_to_lidar = np.linalg.inv(lidar_to_base)
+	base_to_world = np.dot(lidar_to_base, np.dot(lidar_to_world, base_to_lidar))
+	return base_to_world
+
+
+def write_transformed_pose(estimate_file, base_to_world) -> None:
+	np.savetxt(estimate_file, base_to_world[:3].reshape(-1, 12))

--- a/mad_icp/configurations/rviz/mad_icp_rviz_odom_and_cloud.rviz
+++ b/mad_icp/configurations/rviz/mad_icp_rviz_odom_and_cloud.rviz
@@ -1,0 +1,211 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Odometry1/Status1
+        - /PointCloud21
+        - /PointCloud22
+      Splitter Ratio: 0.5
+    Tree Height: 559
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 50
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 500
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Axes
+      Topic: /odometry/imu
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 11.872307777404785
+        Min Value: -2.846092700958252
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: AxisColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 240; 240; 20
+      Min Color: 0; 0; 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.05000000074505806
+      Style: Flat Squares
+      Topic: /cloud/complete
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.07999999821186066
+      Style: Flat Squares
+      Topic: /cloud/current
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 38.29419708251953
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: 0.6745279431343079
+        Y: 9.059837341308594
+        Z: -1.5437724590301514
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.47479620575904846
+      Target Frame: <Fixed Frame>
+      Yaw: 4.417241096496582
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 850
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd00000004000000000000024c000002b8fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b000002b8000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b8fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003b000002b8000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007290000003efc0100000002fb0000000800540069006d00650100000000000007290000030700fffffffb0000000800540069006d00650100000000000004500000000000000000000004d7000002b800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1833
+  X: 80
+  Y: 310


### PR DESCRIPTION
Hi!

Here's a small extension to your work that adds an optional ROS1 publisher. Hope that will be useful :)

This PR has one limitation regarding ROS clock handling: while all your work and the published messages that I added here use correct timestamps from the original ROS bag file, the ROS log messages (and RViz main display) use clock from `roscore`. This can be addressed in the future, hopefully with little extra effort.

Update: This has been tested on Hilti 2021 datasets.

Let me know if there is something I can improve to see this PR merged :)

Here's a small sample:
<img width="1842" height="1168" alt="Screenshot from 2025-08-31 09-32-59" src="https://github.com/user-attachments/assets/48e289da-85b7-4e5c-9aae-f84f34a407d5" />

Kind regards!